### PR TITLE
Add modern forced induction engine library

### DIFF
--- a/assets/engines/modern/forced_induction_collection.mr
+++ b/assets/engines/modern/forced_induction_collection.mr
@@ -1,0 +1,1737 @@
+import "engine_sim.mr"
+
+units units()
+constants constants()
+impulse_response_library ir_lib()
+label cycle(2 * 360 * units.deg)
+
+private node wires_i4 {
+    output wire1: ignition_wire();
+    output wire2: ignition_wire();
+    output wire3: ignition_wire();
+    output wire4: ignition_wire();
+}
+
+private node wires_i6 {
+    output wire1: ignition_wire();
+    output wire2: ignition_wire();
+    output wire3: ignition_wire();
+    output wire4: ignition_wire();
+    output wire5: ignition_wire();
+    output wire6: ignition_wire();
+}
+
+private node wires_v8 {
+    output wire1: ignition_wire();
+    output wire2: ignition_wire();
+    output wire3: ignition_wire();
+    output wire4: ignition_wire();
+    output wire5: ignition_wire();
+    output wire6: ignition_wire();
+    output wire7: ignition_wire();
+    output wire8: ignition_wire();
+}
+
+private node performance_pump_fuel {
+    alias output __out:
+        fuel(
+            name: "Performance 98 Octane",
+            molecular_mass: 110 * units.g,
+            energy_density: 44.0 * units.kJ / units.g,
+            density: 0.74 * units.kg / units.L,
+            molecular_afr: 14.1,
+            max_burning_efficiency: 0.98,
+            burning_efficiency_randomness: 0.05,
+            max_turbulence_effect: 4.0,
+            max_dilution_effect: 12.0
+        );
+}
+private node modern_i4_camshaft_builder {
+    input lobe_profile: harmonic_cam_lobe(
+        duration_at_50_thou: 248 * units.deg,
+        gamma: 1.05,
+        lift: 12.0 * units.mm,
+        steps: 120
+    );
+    input intake_lobe_profile: lobe_profile;
+    input exhaust_lobe_profile: lobe_profile;
+    input lobe_separation: 108.0 * units.deg;
+    input intake_lobe_center: lobe_separation;
+    input exhaust_lobe_center: lobe_separation;
+    input advance: 0.0 * units.deg;
+    input base_radius: 0.95 * units.inch;
+
+    output intake_cam: _intake_cam;
+    output exhaust_cam: _exhaust_cam;
+
+    camshaft_parameters params(
+        advance: advance,
+        base_radius: base_radius
+    )
+
+    camshaft _intake_cam(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam(params, lobe_profile: exhaust_lobe_profile)
+
+    label rot(2 * (360 / 4.0) * units.deg)
+    label rot360(360 * units.deg)
+
+    _exhaust_cam
+        .add_lobe(rot360 - exhaust_lobe_center + 0 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 1 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 2 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 3 * rot)
+
+    _intake_cam
+        .add_lobe(rot360 + intake_lobe_center + 0 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 1 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 2 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 3 * rot)
+}
+
+private node modern_i4_head {
+    input intake_camshaft;
+    input exhaust_camshaft;
+    input chamber_volume: 46 * units.cc;
+    input intake_runner_volume: 190 * units.cc;
+    input intake_runner_cross_section_area: (1.55 * units.inch) * (1.55 * units.inch);
+    input exhaust_runner_volume: 90 * units.cc;
+    input exhaust_runner_cross_section_area: (1.35 * units.inch) * (1.35 * units.inch);
+
+    input flow_attenuation: 1.0;
+    input lift_scale: 1.0;
+    input flip_display: false;
+    alias output __out: head;
+
+    function intake_flow(50 * units.thou)
+    intake_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 60 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 110 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 160 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 210 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 240 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 265 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 280 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 288 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 295 * flow_attenuation)
+
+    function exhaust_flow(50 * units.thou)
+    exhaust_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 45 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 85 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 125 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 165 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 190 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 205 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 215 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 220 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 225 * flow_attenuation)
+
+    generic_cylinder_head head(
+        chamber_volume: chamber_volume,
+        intake_runner_volume: intake_runner_volume,
+        intake_runner_cross_section_area: intake_runner_cross_section_area,
+        exhaust_runner_volume: exhaust_runner_volume,
+        exhaust_runner_cross_section_area: exhaust_runner_cross_section_area,
+
+        intake_port_flow: intake_flow,
+        exhaust_port_flow: exhaust_flow,
+        valvetrain: standard_valvetrain(
+            intake_camshaft: intake_camshaft,
+            exhaust_camshaft: exhaust_camshaft
+        ),
+        flip_display: flip_display
+    )
+}
+private node modern_i4_base {
+    input engine_name [string]: "Modern Forced-Induction I4";
+    input forced_induction_type [string]: "turbocharger";
+    input forced_induction_max_boost: 28 * units.psi;
+    input forced_induction_spool_time: 0.45;
+    input forced_induction_decay_time: 0.5;
+    input forced_induction_efficiency: 0.75;
+    input forced_induction_idle_fraction: 0.12;
+    input redline: 7200 * units.rpm;
+    input fuel: performance_pump_fuel();
+
+    input bore: 83.0 * units.mm;
+    input stroke: 92.0 * units.mm;
+    input rod_length: 5.7 * units.inch;
+    input compression_height: 1.20 * units.inch;
+    input piston_mass: 420 * units.g;
+    input rod_mass: 620 * units.g;
+
+    input chamber_volume: 46 * units.cc;
+    input intake_runner_volume: 190 * units.cc;
+    input intake_runner_cross_section_area: (1.55 * units.inch) * (1.55 * units.inch);
+    input exhaust_runner_volume: 90 * units.cc;
+    input exhaust_runner_cross_section_area: (1.35 * units.inch) * (1.35 * units.inch);
+
+    input plenum_volume: 5.5 * units.L;
+    input plenum_cross_section_area: 32.0 * units.cm2;
+    input intake_flow_rate: k_carb(650.0);
+    input idle_flow_rate: k_carb(5.0);
+    input runner_flow_rate: k_carb(360.0);
+    input runner_length: 8.0 * units.inch;
+    input velocity_decay: 0.45;
+
+    input exhaust_volume: 15.0 * units.L;
+    input exhaust_primary_length: 32.0 * units.inch;
+    input exhaust_primary_flow_rate: k_carb(650.0);
+    input exhaust_outlet_flow_rate: k_carb(800.0);
+    input exhaust_audio_volume: 0.85;
+
+    alias output __out: engine;
+
+    engine engine(
+        name: engine_name,
+        starter_torque: 150 * units.lb_ft,
+        starter_speed: 350 * units.rpm,
+        redline: redline,
+        fuel: fuel,
+        throttle_gamma: 2.0,
+        hf_gain: 0.0035,
+        noise: 0.28,
+        jitter: 0.08,
+        simulation_frequency: 32000
+    )
+
+    wires_i4 wires()
+
+    crankshaft c0(
+        throw: stroke / 2,
+        flywheel_mass: 22 * units.lb,
+        mass: 52 * units.lb,
+        friction_torque: 20 * units.lb_ft,
+        moment_of_inertia: 0.32,
+        position_x: 0.0,
+        position_y: 0.0,
+        tdc: 90 * units.deg
+    )
+
+    rod_journal rj0(angle: 0.0 * units.deg)
+    rod_journal rj1(angle: 180.0 * units.deg)
+    rod_journal rj2(angle: 180.0 * units.deg)
+    rod_journal rj3(angle: 0.0 * units.deg)
+    c0
+        .add_rod_journal(rj0)
+        .add_rod_journal(rj1)
+        .add_rod_journal(rj2)
+        .add_rod_journal(rj3)
+
+    piston_parameters piston_params(
+        mass: piston_mass,
+        compression_height: compression_height,
+        wrist_pin_position: 0.0,
+        displacement: 0.0
+    )
+
+    connecting_rod_parameters cr_params(
+        mass: rod_mass,
+        moment_of_inertia: 0.0015,
+        center_of_mass: 0.0,
+        length: rod_length
+    )
+
+    intake intake(
+        plenum_volume: plenum_volume,
+        plenum_cross_section_area: plenum_cross_section_area,
+        intake_flow_rate: intake_flow_rate,
+        idle_flow_rate: idle_flow_rate,
+        runner_flow_rate: runner_flow_rate,
+        runner_length: runner_length,
+        idle_throttle_plate_position: 0.995,
+        velocity_decay: velocity_decay,
+        forced_induction_type: forced_induction_type,
+        forced_induction_max_boost: forced_induction_max_boost,
+        forced_induction_spool_time: forced_induction_spool_time,
+        forced_induction_decay_time: forced_induction_decay_time,
+        forced_induction_efficiency: forced_induction_efficiency,
+        forced_induction_idle_fraction: forced_induction_idle_fraction
+    )
+
+    exhaust_system_parameters es_params(
+        outlet_flow_rate: exhaust_outlet_flow_rate,
+        primary_tube_length: exhaust_primary_length,
+        primary_flow_rate: exhaust_primary_flow_rate,
+        velocity_decay: 0.6,
+        volume: exhaust_volume
+    )
+
+    exhaust_system exhaust0(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    exhaust_system exhaust1(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    cylinder_bank_parameters bank_params(
+        bore: bore,
+        deck_height: stroke / 2 + rod_length + compression_height
+    )
+
+    cylinder_bank b0(bank_params, angle: 0.0 * units.deg)
+    b0
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.02)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj0,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire1,
+            sound_attenuation: 0.9
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.03)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj1,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire2,
+            sound_attenuation: 0.95
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.02)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj2,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire3,
+            sound_attenuation: 0.92
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.03)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj3,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire4,
+            sound_attenuation: 0.96
+        )
+
+    engine
+        .add_cylinder_bank(b0)
+
+    engine.add_crankshaft(c0)
+
+    modern_i4_camshaft_builder camshaft()
+
+    b0.set_cylinder_head(
+        modern_i4_head(
+            intake_camshaft: camshaft.intake_cam,
+            exhaust_camshaft: camshaft.exhaust_cam,
+            chamber_volume: chamber_volume,
+            intake_runner_volume: intake_runner_volume,
+            intake_runner_cross_section_area: intake_runner_cross_section_area,
+            exhaust_runner_volume: exhaust_runner_volume,
+            exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+        )
+    )
+
+    function timing_curve(1000 * units.rpm)
+    timing_curve
+        .add_sample(0000 * units.rpm, 10 * units.deg)
+        .add_sample(2000 * units.rpm, 16 * units.deg)
+        .add_sample(3500 * units.rpm, 20 * units.deg)
+        .add_sample(5000 * units.rpm, 24 * units.deg)
+        .add_sample(6500 * units.rpm, 27 * units.deg)
+        .add_sample(7500 * units.rpm, 28 * units.deg)
+
+    ignition_module ignition_module(
+        timing_curve: timing_curve,
+        rev_limit: redline + 500 * units.rpm,
+        limiter_duration: 0.15
+    )
+    ignition_module
+        .connect_wire(wires.wire1, (0.0 / 4.0) * cycle)
+        .connect_wire(wires.wire3, (1.0 / 4.0) * cycle)
+        .connect_wire(wires.wire4, (2.0 / 4.0) * cycle)
+        .connect_wire(wires.wire2, (3.0 / 4.0) * cycle)
+
+    engine.add_ignition_module(ignition_module)
+}
+private node modern_i6_camshaft_builder {
+    input lobe_profile: harmonic_cam_lobe(
+        duration_at_50_thou: 250 * units.deg,
+        gamma: 1.05,
+        lift: 11.5 * units.mm,
+        steps: 120
+    );
+    input intake_lobe_profile: lobe_profile;
+    input exhaust_lobe_profile: lobe_profile;
+    input lobe_separation: 110.0 * units.deg;
+    input intake_lobe_center: lobe_separation;
+    input exhaust_lobe_center: lobe_separation;
+    input advance: 0.0 * units.deg;
+    input base_radius: 0.90 * units.inch;
+
+    output intake_cam: _intake_cam;
+    output exhaust_cam: _exhaust_cam;
+
+    camshaft_parameters params(
+        advance: advance,
+        base_radius: base_radius
+    )
+
+    camshaft _intake_cam(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam(params, lobe_profile: exhaust_lobe_profile)
+
+    label rot(2 * (360 / 6.0) * units.deg)
+    label rot360(360 * units.deg)
+
+    // Firing order 1-5-3-6-2-4
+    _exhaust_cam
+        .add_lobe((rot360 - exhaust_lobe_center) + 0 * rot)
+        .add_lobe((rot360 - exhaust_lobe_center) + 4 * rot)
+        .add_lobe((rot360 - exhaust_lobe_center) + 2 * rot)
+        .add_lobe((rot360 - exhaust_lobe_center) + 5 * rot)
+        .add_lobe((rot360 - exhaust_lobe_center) + 1 * rot)
+        .add_lobe((rot360 - exhaust_lobe_center) + 3 * rot)
+
+    _intake_cam
+        .add_lobe(rot360 + intake_lobe_center + 0 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 4 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 2 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 5 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 1 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 3 * rot)
+}
+
+private node modern_i6_head {
+    input intake_camshaft;
+    input exhaust_camshaft;
+    input chamber_volume: 52 * units.cc;
+    input intake_runner_volume: 240 * units.cc;
+    input intake_runner_cross_section_area: (1.8 * units.inch) * (1.8 * units.inch);
+    input exhaust_runner_volume: 110 * units.cc;
+    input exhaust_runner_cross_section_area: (1.55 * units.inch) * (1.55 * units.inch);
+
+    input flow_attenuation: 1.0;
+    input lift_scale: 1.0;
+    input flip_display: false;
+    alias output __out: head;
+
+    function intake_flow(50 * units.thou)
+    intake_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 70 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 125 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 180 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 235 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 270 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 290 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 305 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 312 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 320 * flow_attenuation)
+
+    function exhaust_flow(50 * units.thou)
+    exhaust_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 55 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 100 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 150 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 195 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 225 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 240 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 250 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 258 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 265 * flow_attenuation)
+
+    generic_cylinder_head head(
+        chamber_volume: chamber_volume,
+        intake_runner_volume: intake_runner_volume,
+        intake_runner_cross_section_area: intake_runner_cross_section_area,
+        exhaust_runner_volume: exhaust_runner_volume,
+        exhaust_runner_cross_section_area: exhaust_runner_cross_section_area,
+
+        intake_port_flow: intake_flow,
+        exhaust_port_flow: exhaust_flow,
+        valvetrain: standard_valvetrain(
+            intake_camshaft: intake_camshaft,
+            exhaust_camshaft: exhaust_camshaft
+        ),
+        flip_display: flip_display
+    )
+}
+
+private node modern_i6_base {
+    input engine_name [string]: "Modern Forced-Induction I6";
+    input forced_induction_type [string]: "turbocharger";
+    input forced_induction_max_boost: 26 * units.psi;
+    input forced_induction_spool_time: 0.50;
+    input forced_induction_decay_time: 0.55;
+    input forced_induction_efficiency: 0.76;
+    input forced_induction_idle_fraction: 0.10;
+    input redline: 7200 * units.rpm;
+    input fuel: performance_pump_fuel();
+
+    input bore: 82.0 * units.mm;
+    input stroke: 94.6 * units.mm;
+    input rod_length: 6.0 * units.inch;
+    input compression_height: 1.20 * units.inch;
+    input piston_mass: 500 * units.g;
+    input rod_mass: 700 * units.g;
+
+    input chamber_volume: 52 * units.cc;
+    input intake_runner_volume: 240 * units.cc;
+    input intake_runner_cross_section_area: (1.8 * units.inch) * (1.8 * units.inch);
+    input exhaust_runner_volume: 110 * units.cc;
+    input exhaust_runner_cross_section_area: (1.55 * units.inch) * (1.55 * units.inch);
+
+    input plenum_volume: 8.0 * units.L;
+    input plenum_cross_section_area: 45.0 * units.cm2;
+    input intake_flow_rate: k_carb(850.0);
+    input idle_flow_rate: k_carb(10.0);
+    input runner_flow_rate: k_carb(450.0);
+    input runner_length: 10.0 * units.inch;
+    input velocity_decay: 0.40;
+
+    input exhaust_volume: 22.0 * units.L;
+    input exhaust_primary_length: 34.0 * units.inch;
+    input exhaust_primary_flow_rate: k_carb(850.0);
+    input exhaust_outlet_flow_rate: k_carb(1200.0);
+    input exhaust_audio_volume: 0.9;
+
+    alias output __out: engine;
+
+    engine engine(
+        name: engine_name,
+        starter_torque: 180 * units.lb_ft,
+        starter_speed: 320 * units.rpm,
+        redline: redline,
+        fuel: fuel,
+        throttle_gamma: 2.1,
+        hf_gain: 0.003,
+        noise: 0.26,
+        jitter: 0.09,
+        simulation_frequency: 32000
+    )
+
+    wires_i6 wires()
+
+    crankshaft c0(
+        throw: stroke / 2,
+        flywheel_mass: 28 * units.lb,
+        mass: 60 * units.lb,
+        friction_torque: 25 * units.lb_ft,
+        moment_of_inertia: 0.40,
+        position_x: 0.0,
+        position_y: 0.0,
+        tdc: constants.pi / 2
+    )
+
+    rod_journal rj0(angle: 0 * units.deg)
+    rod_journal rj1(angle: 480 * units.deg)
+    rod_journal rj2(angle: 240 * units.deg)
+    rod_journal rj3(angle: 600 * units.deg)
+    rod_journal rj4(angle: 120 * units.deg)
+    rod_journal rj5(angle: 360 * units.deg)
+    c0
+        .add_rod_journal(rj0)
+        .add_rod_journal(rj1)
+        .add_rod_journal(rj2)
+        .add_rod_journal(rj3)
+        .add_rod_journal(rj4)
+        .add_rod_journal(rj5)
+
+    piston_parameters piston_params(
+        mass: piston_mass,
+        compression_height: compression_height,
+        wrist_pin_position: 0.0,
+        displacement: 0.0
+    )
+
+    connecting_rod_parameters cr_params(
+        mass: rod_mass,
+        moment_of_inertia: 0.0022,
+        center_of_mass: 0.0,
+        length: rod_length
+    )
+
+    intake intake(
+        plenum_volume: plenum_volume,
+        plenum_cross_section_area: plenum_cross_section_area,
+        intake_flow_rate: intake_flow_rate,
+        idle_flow_rate: idle_flow_rate,
+        runner_flow_rate: runner_flow_rate,
+        runner_length: runner_length,
+        idle_throttle_plate_position: 0.992,
+        velocity_decay: velocity_decay,
+        forced_induction_type: forced_induction_type,
+        forced_induction_max_boost: forced_induction_max_boost,
+        forced_induction_spool_time: forced_induction_spool_time,
+        forced_induction_decay_time: forced_induction_decay_time,
+        forced_induction_efficiency: forced_induction_efficiency,
+        forced_induction_idle_fraction: forced_induction_idle_fraction
+    )
+
+    exhaust_system_parameters es_params(
+        outlet_flow_rate: exhaust_outlet_flow_rate,
+        primary_tube_length: exhaust_primary_length,
+        primary_flow_rate: exhaust_primary_flow_rate,
+        velocity_decay: 0.5,
+        volume: exhaust_volume
+    )
+
+    exhaust_system exhaust0(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    exhaust_system exhaust1(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    cylinder_bank_parameters bank_params(
+        bore: bore,
+        deck_height: stroke / 2 + rod_length + compression_height
+    )
+
+    cylinder_bank b0(bank_params, angle: 0)
+    label spacing(0.45 * units.inch)
+    b0
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj0,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire1,
+            primary_length: spacing * 5,
+            sound_attenuation: 0.9
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj1,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire2,
+            primary_length: spacing * 4,
+            sound_attenuation: 0.92
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj2,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire3,
+            primary_length: spacing * 3,
+            sound_attenuation: 0.94
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj3,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire4,
+            primary_length: spacing * 3,
+            sound_attenuation: 0.96
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj4,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire5,
+            primary_length: spacing * 4,
+            sound_attenuation: 0.95
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj5,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire6,
+            primary_length: spacing * 5,
+            sound_attenuation: 0.93
+        )
+
+    engine
+        .add_cylinder_bank(b0)
+
+    engine.add_crankshaft(c0)
+
+    modern_i6_camshaft_builder camshaft()
+
+    b0.set_cylinder_head(
+        modern_i6_head(
+            intake_camshaft: camshaft.intake_cam,
+            exhaust_camshaft: camshaft.exhaust_cam,
+            chamber_volume: chamber_volume,
+            intake_runner_volume: intake_runner_volume,
+            intake_runner_cross_section_area: intake_runner_cross_section_area,
+            exhaust_runner_volume: exhaust_runner_volume,
+            exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+        )
+    )
+
+    function timing_curve(1000 * units.rpm)
+    timing_curve
+        .add_sample(0000 * units.rpm, 10 * units.deg)
+        .add_sample(1500 * units.rpm, 14 * units.deg)
+        .add_sample(3000 * units.rpm, 18 * units.deg)
+        .add_sample(4500 * units.rpm, 23 * units.deg)
+        .add_sample(6000 * units.rpm, 26 * units.deg)
+        .add_sample(7000 * units.rpm, 28 * units.deg)
+
+    ignition_module ignition_module(
+        timing_curve: timing_curve,
+        rev_limit: redline + 400 * units.rpm,
+        limiter_duration: 0.18
+    )
+    ignition_module
+        .connect_wire(wires.wire1, (0.0 / 6.0) * cycle)
+        .connect_wire(wires.wire5, (1.0 / 6.0) * cycle)
+        .connect_wire(wires.wire3, (2.0 / 6.0) * cycle)
+        .connect_wire(wires.wire6, (3.0 / 6.0) * cycle)
+        .connect_wire(wires.wire2, (4.0 / 6.0) * cycle)
+        .connect_wire(wires.wire4, (5.0 / 6.0) * cycle)
+
+    engine.add_ignition_module(ignition_module)
+}
+private node modern_v6_camshaft_builder {
+    input lobe_profile: harmonic_cam_lobe(
+        duration_at_50_thou: 244 * units.deg,
+        gamma: 1.04,
+        lift: 11.0 * units.mm,
+        steps: 120
+    );
+    input intake_lobe_profile: lobe_profile;
+    input exhaust_lobe_profile: lobe_profile;
+    input lobe_separation: 112.0 * units.deg;
+    input intake_lobe_center: lobe_separation;
+    input exhaust_lobe_center: lobe_separation;
+    input advance: 0.0 * units.deg;
+    input base_radius: 0.90 * units.inch;
+
+    output intake_cam_0: _intake_cam_0;
+    output exhaust_cam_0: _exhaust_cam_0;
+    output intake_cam_1: _intake_cam_1;
+    output exhaust_cam_1: _exhaust_cam_1;
+
+    camshaft_parameters params(
+        advance: advance,
+        base_radius: base_radius
+    )
+
+    camshaft _intake_cam_0(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam_0(params, lobe_profile: exhaust_lobe_profile)
+    camshaft _intake_cam_1(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam_1(params, lobe_profile: exhaust_lobe_profile)
+
+    label rot360(360 * units.deg)
+
+    _exhaust_cam_0
+        .add_lobe(rot360 - exhaust_lobe_center + 0 * units.deg)
+        .add_lobe(rot360 - exhaust_lobe_center + 240 * units.deg)
+        .add_lobe(rot360 - exhaust_lobe_center + 480 * units.deg)
+    _intake_cam_0
+        .add_lobe(rot360 + intake_lobe_center + 0 * units.deg)
+        .add_lobe(rot360 + intake_lobe_center + 240 * units.deg)
+        .add_lobe(rot360 + intake_lobe_center + 480 * units.deg)
+
+    _exhaust_cam_1
+        .add_lobe(rot360 - exhaust_lobe_center + 120 * units.deg)
+        .add_lobe(rot360 - exhaust_lobe_center + 360 * units.deg)
+        .add_lobe(rot360 - exhaust_lobe_center + 600 * units.deg)
+    _intake_cam_1
+        .add_lobe(rot360 + intake_lobe_center + 120 * units.deg)
+        .add_lobe(rot360 + intake_lobe_center + 360 * units.deg)
+        .add_lobe(rot360 + intake_lobe_center + 600 * units.deg)
+}
+
+private node modern_v6_head {
+    input intake_camshaft;
+    input exhaust_camshaft;
+    input chamber_volume: 62 * units.cc;
+    input intake_runner_volume: 220 * units.cc;
+    input intake_runner_cross_section_area: (1.75 * units.inch) * (1.75 * units.inch);
+    input exhaust_runner_volume: 100 * units.cc;
+    input exhaust_runner_cross_section_area: (1.5 * units.inch) * (1.5 * units.inch);
+
+    input flow_attenuation: 1.0;
+    input lift_scale: 1.0;
+    input flip_display: false;
+    alias output __out: head;
+
+    function intake_flow(50 * units.thou)
+    intake_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 68 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 120 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 175 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 220 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 250 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 270 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 282 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 288 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 295 * flow_attenuation)
+
+    function exhaust_flow(50 * units.thou)
+    exhaust_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 52 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 98 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 145 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 188 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 215 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 230 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 240 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 246 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 250 * flow_attenuation)
+
+    generic_cylinder_head head(
+        chamber_volume: chamber_volume,
+        intake_runner_volume: intake_runner_volume,
+        intake_runner_cross_section_area: intake_runner_cross_section_area,
+        exhaust_runner_volume: exhaust_runner_volume,
+        exhaust_runner_cross_section_area: exhaust_runner_cross_section_area,
+
+        intake_port_flow: intake_flow,
+        exhaust_port_flow: exhaust_flow,
+        valvetrain: standard_valvetrain(
+            intake_camshaft: intake_camshaft,
+            exhaust_camshaft: exhaust_camshaft
+        ),
+        flip_display: flip_display
+    )
+}
+
+private node modern_v6_base {
+    input engine_name [string]: "Modern Forced-Induction V6";
+    input forced_induction_type [string]: "turbocharger";
+    input forced_induction_max_boost: 30 * units.psi;
+    input forced_induction_spool_time: 0.40;
+    input forced_induction_decay_time: 0.45;
+    input forced_induction_efficiency: 0.74;
+    input forced_induction_idle_fraction: 0.12;
+    input redline: 7500 * units.rpm;
+    input fuel: performance_pump_fuel();
+
+    input bore: 95.5 * units.mm;
+    input stroke: 88.4 * units.mm;
+    input rod_length: 6.0 * units.inch;
+    input compression_height: 1.18 * units.inch;
+    input piston_mass: 540 * units.g;
+    input rod_mass: 720 * units.g;
+
+    input chamber_volume: 62 * units.cc;
+    input intake_runner_volume: 220 * units.cc;
+    input intake_runner_cross_section_area: (1.75 * units.inch) * (1.75 * units.inch);
+    input exhaust_runner_volume: 100 * units.cc;
+    input exhaust_runner_cross_section_area: (1.5 * units.inch) * (1.5 * units.inch);
+
+    input plenum_volume: 6.5 * units.L;
+    input plenum_cross_section_area: 42.0 * units.cm2;
+    input intake_flow_rate: k_carb(900.0);
+    input idle_flow_rate: k_carb(8.0);
+    input runner_flow_rate: k_carb(500.0);
+    input runner_length: 7.5 * units.inch;
+    input velocity_decay: 0.42;
+
+    input exhaust_volume: 20.0 * units.L;
+    input exhaust_primary_length: 28.0 * units.inch;
+    input exhaust_primary_flow_rate: k_carb(900.0);
+    input exhaust_outlet_flow_rate: k_carb(1300.0);
+    input exhaust_audio_volume: 1.0;
+
+    alias output __out: engine;
+
+    engine engine(
+        name: engine_name,
+        starter_torque: 200 * units.lb_ft,
+        starter_speed: 320 * units.rpm,
+        redline: redline,
+        fuel: fuel,
+        throttle_gamma: 2.1,
+        hf_gain: 0.0032,
+        noise: 0.30,
+        jitter: 0.10,
+        simulation_frequency: 32000
+    )
+
+    wires_i6 wires()
+
+    crankshaft c0(
+        throw: stroke / 2,
+        flywheel_mass: 32 * units.lb,
+        mass: 75 * units.lb,
+        friction_torque: 28 * units.lb_ft,
+        moment_of_inertia: 0.45,
+        position_x: 0.0,
+        position_y: 0.0,
+        tdc: constants.pi / 2
+    )
+
+    rod_journal rj0(angle: 0.0 * units.deg)
+    rod_journal rj1(angle: (0 + 60) * units.deg)
+    rod_journal rj2(angle: 240.0 * units.deg)
+    rod_journal rj3(angle: (240.0 + 60) * units.deg)
+    rod_journal rj4(angle: 120.0 * units.deg)
+    rod_journal rj5(angle: (120.0 + 60) * units.deg)
+    c0
+        .add_rod_journal(rj0)
+        .add_rod_journal(rj1)
+        .add_rod_journal(rj2)
+        .add_rod_journal(rj3)
+        .add_rod_journal(rj4)
+        .add_rod_journal(rj5)
+
+    piston_parameters piston_params(
+        mass: piston_mass,
+        compression_height: compression_height,
+        wrist_pin_position: 0.0,
+        displacement: 0.0
+    )
+
+    connecting_rod_parameters cr_params(
+        mass: rod_mass,
+        moment_of_inertia: 0.0024,
+        center_of_mass: 0.0,
+        length: rod_length
+    )
+
+    intake intake(
+        plenum_volume: plenum_volume,
+        plenum_cross_section_area: plenum_cross_section_area,
+        intake_flow_rate: intake_flow_rate,
+        idle_flow_rate: idle_flow_rate,
+        runner_flow_rate: runner_flow_rate,
+        runner_length: runner_length,
+        idle_throttle_plate_position: 0.99,
+        velocity_decay: velocity_decay,
+        forced_induction_type: forced_induction_type,
+        forced_induction_max_boost: forced_induction_max_boost,
+        forced_induction_spool_time: forced_induction_spool_time,
+        forced_induction_decay_time: forced_induction_decay_time,
+        forced_induction_efficiency: forced_induction_efficiency,
+        forced_induction_idle_fraction: forced_induction_idle_fraction
+    )
+
+    exhaust_system_parameters es_params(
+        outlet_flow_rate: exhaust_outlet_flow_rate,
+        primary_tube_length: exhaust_primary_length,
+        primary_flow_rate: exhaust_primary_flow_rate,
+        velocity_decay: 0.55,
+        volume: exhaust_volume
+    )
+
+    exhaust_system exhaust0(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+    exhaust_system exhaust1(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    cylinder_bank_parameters bank_params(
+        bore: bore,
+        deck_height: stroke / 2 + rod_length + compression_height
+    )
+
+    cylinder_bank b0(bank_params, angle: 30.0 * units.deg)
+    cylinder_bank b1(bank_params, angle: -30.0 * units.deg)
+
+    label primary_spacing(4.5 * units.inch)
+
+    modern_v6_camshaft_builder camshaft()
+
+    b0
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.04)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj0,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire1,
+            primary_length: primary_spacing * 2,
+            sound_attenuation: 0.92
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj2,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire3,
+            primary_length: primary_spacing * 1,
+            sound_attenuation: 0.95
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj4,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire5,
+            primary_length: primary_spacing * 0,
+            sound_attenuation: 0.96
+        )
+        .set_cylinder_head(
+            modern_v6_head(
+                intake_camshaft: camshaft.intake_cam_0,
+                exhaust_camshaft: camshaft.exhaust_cam_0,
+                flip_display: true,
+                chamber_volume: chamber_volume,
+                intake_runner_volume: intake_runner_volume,
+                intake_runner_cross_section_area: intake_runner_cross_section_area,
+                exhaust_runner_volume: exhaust_runner_volume,
+                exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+            )
+        )
+
+    b1
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.04)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj1,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire2,
+            primary_length: primary_spacing * 2,
+            sound_attenuation: 0.94
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj3,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire4,
+            primary_length: primary_spacing * 1,
+            sound_attenuation: 0.92
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj5,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire6,
+            primary_length: primary_spacing * 0,
+            sound_attenuation: 0.96
+        )
+        .set_cylinder_head(
+            modern_v6_head(
+                intake_camshaft: camshaft.intake_cam_1,
+                exhaust_camshaft: camshaft.exhaust_cam_1,
+                chamber_volume: chamber_volume,
+                intake_runner_volume: intake_runner_volume,
+                intake_runner_cross_section_area: intake_runner_cross_section_area,
+                exhaust_runner_volume: exhaust_runner_volume,
+                exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+            )
+        )
+
+    engine
+        .add_cylinder_bank(b0)
+        .add_cylinder_bank(b1)
+
+    engine.add_crankshaft(c0)
+
+    function timing_curve(1000 * units.rpm)
+    timing_curve
+        .add_sample(0000 * units.rpm, 8 * units.deg)
+        .add_sample(2000 * units.rpm, 14 * units.deg)
+        .add_sample(3500 * units.rpm, 20 * units.deg)
+        .add_sample(5000 * units.rpm, 24 * units.deg)
+        .add_sample(6500 * units.rpm, 26 * units.deg)
+        .add_sample(7500 * units.rpm, 27 * units.deg)
+
+    ignition_module ignition_module(
+        timing_curve: timing_curve,
+        rev_limit: redline + 300 * units.rpm,
+        limiter_duration: 0.18
+    )
+    ignition_module
+        .connect_wire(wires.wire1, 0 * units.deg)
+        .connect_wire(wires.wire2, 120 * units.deg)
+        .connect_wire(wires.wire3, 240 * units.deg)
+        .connect_wire(wires.wire4, 360 * units.deg)
+        .connect_wire(wires.wire5, 480 * units.deg)
+        .connect_wire(wires.wire6, 600 * units.deg)
+
+    engine.add_ignition_module(ignition_module)
+}
+private node modern_v8_camshaft_builder {
+    input lobe_profile: harmonic_cam_lobe(
+        duration_at_50_thou: 252 * units.deg,
+        gamma: 1.05,
+        lift: 12.5 * units.mm,
+        steps: 120
+    );
+    input intake_lobe_profile: lobe_profile;
+    input exhaust_lobe_profile: lobe_profile;
+    input lobe_separation: 114.0 * units.deg;
+    input intake_lobe_center: lobe_separation;
+    input exhaust_lobe_center: lobe_separation;
+    input advance: 0.0 * units.deg;
+    input base_radius: 0.90 * units.inch;
+
+    output intake_cam_0: _intake_cam_0;
+    output exhaust_cam_0: _exhaust_cam_0;
+    output intake_cam_1: _intake_cam_1;
+    output exhaust_cam_1: _exhaust_cam_1;
+
+    camshaft_parameters params(
+        advance: advance,
+        base_radius: base_radius
+    )
+
+    camshaft _intake_cam_0(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam_0(params, lobe_profile: exhaust_lobe_profile)
+    camshaft _intake_cam_1(params, lobe_profile: intake_lobe_profile)
+    camshaft _exhaust_cam_1(params, lobe_profile: exhaust_lobe_profile)
+
+    label rot(90 * units.deg)
+    label rot360(360 * units.deg)
+
+    // 1 8 7 2 6 5 4 3
+    _exhaust_cam_0
+        .add_lobe(rot360 - exhaust_lobe_center + 0 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 7 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 5 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 2 * rot)
+    _intake_cam_0
+        .add_lobe(rot360 + intake_lobe_center + 0 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 7 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 5 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 2 * rot)
+
+    _exhaust_cam_1
+        .add_lobe(rot360 - exhaust_lobe_center + 3 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 6 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 4 * rot)
+        .add_lobe(rot360 - exhaust_lobe_center + 1 * rot)
+    _intake_cam_1
+        .add_lobe(rot360 + intake_lobe_center + 3 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 6 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 4 * rot)
+        .add_lobe(rot360 + intake_lobe_center + 1 * rot)
+}
+
+private node modern_v8_head {
+    input intake_camshaft;
+    input exhaust_camshaft;
+    input chamber_volume: 88 * units.cc;
+    input intake_runner_volume: 250 * units.cc;
+    input intake_runner_cross_section_area: (2.1 * units.inch) * (2.1 * units.inch);
+    input exhaust_runner_volume: 110 * units.cc;
+    input exhaust_runner_cross_section_area: (1.7 * units.inch) * (1.7 * units.inch);
+
+    input flow_attenuation: 1.0;
+    input lift_scale: 1.0;
+    input flip_display: false;
+    alias output __out: head;
+
+    function intake_flow(50 * units.thou)
+    intake_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 75 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 130 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 190 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 240 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 275 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 295 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 308 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 314 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 320 * flow_attenuation)
+
+    function exhaust_flow(50 * units.thou)
+    exhaust_flow
+        .add_flow_sample(0 * lift_scale, 0 * flow_attenuation)
+        .add_flow_sample(50 * lift_scale, 58 * flow_attenuation)
+        .add_flow_sample(100 * lift_scale, 108 * flow_attenuation)
+        .add_flow_sample(150 * lift_scale, 160 * flow_attenuation)
+        .add_flow_sample(200 * lift_scale, 205 * flow_attenuation)
+        .add_flow_sample(250 * lift_scale, 235 * flow_attenuation)
+        .add_flow_sample(300 * lift_scale, 250 * flow_attenuation)
+        .add_flow_sample(350 * lift_scale, 262 * flow_attenuation)
+        .add_flow_sample(400 * lift_scale, 268 * flow_attenuation)
+        .add_flow_sample(450 * lift_scale, 272 * flow_attenuation)
+
+    generic_cylinder_head head(
+        chamber_volume: chamber_volume,
+        intake_runner_volume: intake_runner_volume,
+        intake_runner_cross_section_area: intake_runner_cross_section_area,
+        exhaust_runner_volume: exhaust_runner_volume,
+        exhaust_runner_cross_section_area: exhaust_runner_cross_section_area,
+
+        intake_port_flow: intake_flow,
+        exhaust_port_flow: exhaust_flow,
+        valvetrain: standard_valvetrain(
+            intake_camshaft: intake_camshaft,
+            exhaust_camshaft: exhaust_camshaft
+        ),
+        flip_display: flip_display
+    )
+}
+
+private node modern_v8_base {
+    input engine_name [string]: "Modern Forced-Induction V8";
+    input forced_induction_type [string]: "turbocharger";
+    input forced_induction_max_boost: 24 * units.psi;
+    input forced_induction_spool_time: 0.35;
+    input forced_induction_decay_time: 0.40;
+    input forced_induction_efficiency: 0.78;
+    input forced_induction_idle_fraction: 0.15;
+    input redline: 7800 * units.rpm;
+    input fuel: performance_pump_fuel();
+
+    input bore: 92.0 * units.mm;
+    input stroke: 86.0 * units.mm;
+    input rod_length: 6.1 * units.inch;
+    input compression_height: 1.18 * units.inch;
+    input piston_mass: 600 * units.g;
+    input rod_mass: 740 * units.g;
+
+    input chamber_volume: 88 * units.cc;
+    input intake_runner_volume: 250 * units.cc;
+    input intake_runner_cross_section_area: (2.1 * units.inch) * (2.1 * units.inch);
+    input exhaust_runner_volume: 110 * units.cc;
+    input exhaust_runner_cross_section_area: (1.7 * units.inch) * (1.7 * units.inch);
+
+    input plenum_volume: 9.5 * units.L;
+    input plenum_cross_section_area: 55.0 * units.cm2;
+    input intake_flow_rate: k_carb(1100.0);
+    input idle_flow_rate: k_carb(12.0);
+    input runner_flow_rate: k_carb(600.0);
+    input runner_length: 7.0 * units.inch;
+    input velocity_decay: 0.38;
+
+    input exhaust_volume: 28.0 * units.L;
+    input exhaust_primary_length: 30.0 * units.inch;
+    input exhaust_primary_flow_rate: k_carb(1100.0);
+    input exhaust_outlet_flow_rate: k_carb(1500.0);
+    input exhaust_audio_volume: 1.2;
+
+    alias output __out: engine;
+
+    engine engine(
+        name: engine_name,
+        starter_torque: 240 * units.lb_ft,
+        starter_speed: 300 * units.rpm,
+        redline: redline,
+        fuel: fuel,
+        throttle_gamma: 2.15,
+        hf_gain: 0.003,
+        noise: 0.32,
+        jitter: 0.11,
+        simulation_frequency: 32000
+    )
+
+    wires_v8 wires()
+
+    label v_angle(90 * units.deg)
+
+    crankshaft c0(
+        throw: stroke / 2,
+        flywheel_mass: 40 * units.lb,
+        mass: 90 * units.lb,
+        friction_torque: 32 * units.lb_ft,
+        moment_of_inertia: 0.55,
+        position_x: 0.0,
+        position_y: 0.0,
+        tdc: 90 * units.deg - (v_angle / 2.0)
+    )
+
+    rod_journal rj0(angle: 0 * units.deg)
+    rod_journal rj1(angle: 270 * units.deg)
+    rod_journal rj2(angle: 90 * units.deg)
+    rod_journal rj3(angle: 180 * units.deg)
+    c0
+        .add_rod_journal(rj0)
+        .add_rod_journal(rj1)
+        .add_rod_journal(rj2)
+        .add_rod_journal(rj3)
+
+    piston_parameters piston_params(
+        mass: piston_mass,
+        compression_height: compression_height,
+        wrist_pin_position: 0.0,
+        displacement: 0.0
+    )
+
+    connecting_rod_parameters cr_params(
+        mass: rod_mass,
+        moment_of_inertia: 0.0028,
+        center_of_mass: 0.0,
+        length: rod_length
+    )
+
+    intake intake(
+        plenum_volume: plenum_volume,
+        plenum_cross_section_area: plenum_cross_section_area,
+        intake_flow_rate: intake_flow_rate,
+        idle_flow_rate: idle_flow_rate,
+        runner_flow_rate: runner_flow_rate,
+        runner_length: runner_length,
+        idle_throttle_plate_position: 0.985,
+        velocity_decay: velocity_decay,
+        forced_induction_type: forced_induction_type,
+        forced_induction_max_boost: forced_induction_max_boost,
+        forced_induction_spool_time: forced_induction_spool_time,
+        forced_induction_decay_time: forced_induction_decay_time,
+        forced_induction_efficiency: forced_induction_efficiency,
+        forced_induction_idle_fraction: forced_induction_idle_fraction
+    )
+
+    exhaust_system_parameters es_params(
+        outlet_flow_rate: exhaust_outlet_flow_rate,
+        primary_tube_length: exhaust_primary_length,
+        primary_flow_rate: exhaust_primary_flow_rate,
+        velocity_decay: 0.45,
+        volume: exhaust_volume
+    )
+
+    exhaust_system exhaust0(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+    exhaust_system exhaust1(
+        es_params,
+        audio_volume: exhaust_audio_volume,
+        impulse_response: ir_lib.mild_exhaust_0_reverb
+    )
+
+    cylinder_bank_parameters bank_params(
+        bore: bore,
+        deck_height: stroke / 2 + rod_length + compression_height
+    )
+
+    cylinder_bank b0(bank_params, angle: -v_angle / 2.0)
+    cylinder_bank b1(bank_params, angle: v_angle / 2.0)
+
+    modern_v8_camshaft_builder camshaft()
+
+    label primary_spacing(5.0 * units.inch)
+
+    b0
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.04)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj0,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire1,
+            primary_length: primary_spacing * 3,
+            sound_attenuation: 0.90
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj1,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire3,
+            primary_length: primary_spacing * 1,
+            sound_attenuation: 0.94
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj2,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire5,
+            primary_length: primary_spacing * 2,
+            sound_attenuation: 0.92
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj3,
+            intake: intake,
+            exhaust_system: exhaust0,
+            ignition_wire: wires.wire7,
+            primary_length: primary_spacing * 0,
+            sound_attenuation: 0.96
+        )
+        .set_cylinder_head(
+            modern_v8_head(
+                intake_camshaft: camshaft.intake_cam_0,
+                exhaust_camshaft: camshaft.exhaust_cam_0,
+                flip_display: true,
+                chamber_volume: chamber_volume,
+                intake_runner_volume: intake_runner_volume,
+                intake_runner_cross_section_area: intake_runner_cross_section_area,
+                exhaust_runner_volume: exhaust_runner_volume,
+                exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+            )
+        )
+
+    b1
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.04)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj0,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire2,
+            primary_length: primary_spacing * 3,
+            sound_attenuation: 0.93
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj1,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire4,
+            primary_length: primary_spacing * 2,
+            sound_attenuation: 0.95
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj2,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire6,
+            primary_length: primary_spacing * 1,
+            sound_attenuation: 0.94
+        )
+        .add_cylinder(
+            piston: piston(piston_params, blowby: k_28inH2O(0.05)),
+            connecting_rod: connecting_rod(cr_params),
+            rod_journal: rj3,
+            intake: intake,
+            exhaust_system: exhaust1,
+            ignition_wire: wires.wire8,
+            primary_length: primary_spacing * 0,
+            sound_attenuation: 0.96
+        )
+        .set_cylinder_head(
+            modern_v8_head(
+                intake_camshaft: camshaft.intake_cam_1,
+                exhaust_camshaft: camshaft.exhaust_cam_1,
+                chamber_volume: chamber_volume,
+                intake_runner_volume: intake_runner_volume,
+                intake_runner_cross_section_area: intake_runner_cross_section_area,
+                exhaust_runner_volume: exhaust_runner_volume,
+                exhaust_runner_cross_section_area: exhaust_runner_cross_section_area
+            )
+        )
+
+    engine
+        .add_cylinder_bank(b0)
+        .add_cylinder_bank(b1)
+
+    engine.add_crankshaft(c0)
+
+    function timing_curve(1000 * units.rpm)
+    timing_curve
+        .add_sample(0000 * units.rpm, 8 * units.deg)
+        .add_sample(2000 * units.rpm, 14 * units.deg)
+        .add_sample(3500 * units.rpm, 19 * units.deg)
+        .add_sample(5000 * units.rpm, 24 * units.deg)
+        .add_sample(6500 * units.rpm, 26 * units.deg)
+        .add_sample(7800 * units.rpm, 27 * units.deg)
+
+    ignition_module ignition_module(
+        timing_curve: timing_curve,
+        rev_limit: redline + 300 * units.rpm,
+        limiter_duration: 0.18
+    )
+    ignition_module
+        .connect_wire(wires.wire1, (0.0 / 8.0) * cycle)
+        .connect_wire(wires.wire8, (1.0 / 8.0) * cycle)
+        .connect_wire(wires.wire7, (2.0 / 8.0) * cycle)
+        .connect_wire(wires.wire2, (3.0 / 8.0) * cycle)
+        .connect_wire(wires.wire6, (4.0 / 8.0) * cycle)
+        .connect_wire(wires.wire5, (5.0 / 8.0) * cycle)
+        .connect_wire(wires.wire4, (6.0 / 8.0) * cycle)
+        .connect_wire(wires.wire3, (7.0 / 8.0) * cycle)
+
+    engine.add_ignition_module(ignition_module)
+}
+public node amg_m139_inline4 {
+    alias output __out:
+        modern_i4_base(
+            engine_name: "Mercedes-AMG M139 2.0L Turbo I4",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 29 * units.psi,
+            forced_induction_spool_time: 0.38,
+            forced_induction_decay_time: 0.45,
+            forced_induction_efficiency: 0.74,
+            forced_induction_idle_fraction: 0.16,
+            redline: 7200 * units.rpm,
+            bore: 83.0 * units.mm,
+            stroke: 92.0 * units.mm,
+            rod_length: 5.8 * units.inch,
+            piston_mass: 430 * units.g,
+            intake_flow_rate: k_carb(690.0),
+            runner_flow_rate: k_carb(390.0),
+            plenum_volume: 5.6 * units.L,
+            intake_runner_volume: 200 * units.cc,
+            exhaust_outlet_flow_rate: k_carb(950.0),
+            exhaust_audio_volume: 0.9
+        );
+}
+
+public node volvo_polestar_twincharged_inline4 {
+    alias output __out:
+        modern_i4_base(
+            engine_name: "Volvo Drive-E T6 2.0L Twincharged I4",
+            forced_induction_type: "supercharger",
+            forced_induction_max_boost: 22 * units.psi,
+            forced_induction_spool_time: 0.20,
+            forced_induction_decay_time: 0.32,
+            forced_induction_efficiency: 0.82,
+            forced_induction_idle_fraction: 0.25,
+            redline: 6800 * units.rpm,
+            bore: 82.0 * units.mm,
+            stroke: 93.2 * units.mm,
+            piston_mass: 410 * units.g,
+            rod_mass: 600 * units.g,
+            chamber_volume: 50 * units.cc,
+            intake_runner_volume: 210 * units.cc,
+            plenum_volume: 4.8 * units.L,
+            plenum_cross_section_area: 28.0 * units.cm2,
+            intake_flow_rate: k_carb(620.0),
+            runner_flow_rate: k_carb(340.0),
+            exhaust_outlet_flow_rate: k_carb(820.0),
+            exhaust_audio_volume: 0.75
+        );
+}
+
+public node bmw_b58_inline6 {
+    alias output __out:
+        modern_i6_base(
+            engine_name: "BMW B58 3.0L Turbo I6",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 18 * units.psi,
+            forced_induction_spool_time: 0.55,
+            forced_induction_decay_time: 0.60,
+            forced_induction_efficiency: 0.78,
+            forced_induction_idle_fraction: 0.14,
+            redline: 7000 * units.rpm,
+            bore: 82.0 * units.mm,
+            stroke: 94.6 * units.mm,
+            rod_length: 6.0 * units.inch,
+            piston_mass: 520 * units.g,
+            intake_flow_rate: k_carb(780.0),
+            runner_flow_rate: k_carb(430.0),
+            plenum_volume: 7.5 * units.L,
+            exhaust_outlet_flow_rate: k_carb(1100.0),
+            exhaust_audio_volume: 0.85
+        );
+}
+
+public node porsche_911_gt2rs_twin_turbo_flat6 {
+    alias output __out:
+        modern_i6_base(
+            engine_name: "Porsche 911 GT2 RS Clubsport 3.8L Twin Turbo",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 25 * units.psi,
+            forced_induction_spool_time: 0.45,
+            forced_induction_decay_time: 0.50,
+            forced_induction_efficiency: 0.80,
+            forced_induction_idle_fraction: 0.18,
+            redline: 7200 * units.rpm,
+            bore: 102.0 * units.mm,
+            stroke: 77.5 * units.mm,
+            rod_length: 5.6 * units.inch,
+            piston_mass: 500 * units.g,
+            intake_runner_volume: 230 * units.cc,
+            intake_flow_rate: k_carb(900.0),
+            runner_flow_rate: k_carb(480.0),
+            exhaust_outlet_flow_rate: k_carb(1350.0),
+            exhaust_audio_volume: 1.05
+        );
+}
+
+public node nissan_vr38dett_v6 {
+    alias output __out:
+        modern_v6_base(
+            engine_name: "Nissan VR38DETT 3.8L Twin Turbo V6",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 26 * units.psi,
+            forced_induction_spool_time: 0.35,
+            forced_induction_decay_time: 0.40,
+            forced_induction_efficiency: 0.79,
+            forced_induction_idle_fraction: 0.20,
+            redline: 7200 * units.rpm,
+            bore: 95.5 * units.mm,
+            stroke: 88.4 * units.mm,
+            plenum_volume: 6.8 * units.L,
+            intake_flow_rate: k_carb(930.0),
+            runner_flow_rate: k_carb(540.0),
+            exhaust_outlet_flow_rate: k_carb(1400.0),
+            exhaust_audio_volume: 1.1
+        );
+}
+
+public node ford_gt_gte_v6 {
+    alias output __out:
+        modern_v6_base(
+            engine_name: "Ford GT GTE 3.5L Twin Turbo V6",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 24 * units.psi,
+            forced_induction_spool_time: 0.38,
+            forced_induction_decay_time: 0.45,
+            forced_induction_efficiency: 0.77,
+            forced_induction_idle_fraction: 0.18,
+            redline: 7000 * units.rpm,
+            bore: 92.5 * units.mm,
+            stroke: 86.7 * units.mm,
+            plenum_volume: 6.2 * units.L,
+            intake_runner_volume: 210 * units.cc,
+            intake_flow_rate: k_carb(880.0),
+            runner_flow_rate: k_carb(520.0),
+            exhaust_outlet_flow_rate: k_carb(1350.0),
+            exhaust_audio_volume: 1.05
+        );
+}
+
+public node dodge_hellcat_supercharged_v8 {
+    alias output __out:
+        modern_v8_base(
+            engine_name: "Dodge Hellcat 6.2L Supercharged V8",
+            forced_induction_type: "supercharger",
+            forced_induction_max_boost: 14 * units.psi,
+            forced_induction_spool_time: 0.25,
+            forced_induction_decay_time: 0.30,
+            forced_induction_efficiency: 0.82,
+            forced_induction_idle_fraction: 0.35,
+            redline: 6500 * units.rpm,
+            bore: 103.9 * units.mm,
+            stroke: 90.9 * units.mm,
+            rod_length: 6.2 * units.inch,
+            piston_mass: 640 * units.g,
+            plenum_volume: 10.5 * units.L,
+            intake_flow_rate: k_carb(1250.0),
+            runner_flow_rate: k_carb(650.0),
+            exhaust_outlet_flow_rate: k_carb(1600.0),
+            exhaust_audio_volume: 1.4
+        );
+}
+
+public node ferrari_488_gt3_twin_turbo_v8 {
+    alias output __out:
+        modern_v8_base(
+            engine_name: "Ferrari 488 GT3 3.9L Twin Turbo V8",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 27 * units.psi,
+            forced_induction_spool_time: 0.32,
+            forced_induction_decay_time: 0.38,
+            forced_induction_efficiency: 0.80,
+            forced_induction_idle_fraction: 0.16,
+            redline: 8000 * units.rpm,
+            bore: 86.5 * units.mm,
+            stroke: 83.0 * units.mm,
+            rod_length: 6.0 * units.inch,
+            piston_mass: 580 * units.g,
+            plenum_volume: 8.8 * units.L,
+            intake_flow_rate: k_carb(1150.0),
+            runner_flow_rate: k_carb(620.0),
+            exhaust_outlet_flow_rate: k_carb(1550.0),
+            exhaust_audio_volume: 1.25
+        );
+}
+
+public node koenigsegg_jesko_twin_turbo_v8 {
+    alias output __out:
+        modern_v8_base(
+            engine_name: "Koenigsegg Jesko 5.0L Twin Turbo V8",
+            forced_induction_type: "turbocharger",
+            forced_induction_max_boost: 29 * units.psi,
+            forced_induction_spool_time: 0.30,
+            forced_induction_decay_time: 0.36,
+            forced_induction_efficiency: 0.82,
+            forced_induction_idle_fraction: 0.20,
+            redline: 8500 * units.rpm,
+            bore: 95.0 * units.mm,
+            stroke: 92.0 * units.mm,
+            rod_length: 6.2 * units.inch,
+            piston_mass: 570 * units.g,
+            plenum_volume: 9.8 * units.L,
+            intake_flow_rate: k_carb(1250.0),
+            runner_flow_rate: k_carb(640.0),
+            exhaust_outlet_flow_rate: k_carb(1700.0),
+            exhaust_audio_volume: 1.35
+        );
+}
+public node modern_performance_transmission {
+    alias output __out:
+        transmission(
+            max_clutch_torque: 1800 * units.lb_ft
+        )
+            .add_gear(4.50)
+            .add_gear(2.93)
+            .add_gear(2.08)
+            .add_gear(1.69)
+            .add_gear(1.31)
+            .add_gear(1.00)
+            .add_gear(0.82)
+            .add_gear(0.64);
+}
+
+public node modern_track_transmission {
+    alias output __out:
+        transmission(
+            max_clutch_torque: 2200 * units.lb_ft
+        )
+            .add_gear(3.15)
+            .add_gear(2.05)
+            .add_gear(1.60)
+            .add_gear(1.30)
+            .add_gear(1.05)
+            .add_gear(0.88)
+            .add_gear(0.74)
+            .add_gear(0.62);
+}
+
+public node modern_performance_vehicle {
+    alias output __out:
+        vehicle(
+            mass: 1550 * units.kg,
+            drag_coefficient: 0.30,
+            cross_sectional_area: (72 * units.inch) * (52 * units.inch),
+            diff_ratio: 3.30,
+            tire_radius: 13.5 * units.inch,
+            rolling_resistance: 320 * units.N
+        );
+}
+
+public node modern_track_vehicle {
+    alias output __out:
+        vehicle(
+            mass: 1320 * units.kg,
+            drag_coefficient: 0.28,
+            cross_sectional_area: (70 * units.inch) * (48 * units.inch),
+            diff_ratio: 3.80,
+            tire_radius: 12.8 * units.inch,
+            rolling_resistance: 280 * units.N
+        );
+}
+
+public node modern_forced_induction_main {
+    set_engine(amg_m139_inline4())
+    set_transmission(modern_performance_transmission())
+    set_vehicle(modern_performance_vehicle())
+}
+
+public node modern_track_forced_induction_main {
+    set_engine(ferrari_488_gt3_twin_turbo_v8())
+    set_transmission(modern_track_transmission())
+    set_vehicle(modern_track_vehicle())
+}

--- a/assets/main.mr
+++ b/assets/main.mr
@@ -1,6 +1,7 @@
 import "engine_sim.mr"
 import "themes/default.mr"
 import "engines/extreme/insanity_collection.mr"
+import "engines/modern/forced_induction_collection.mr"
 
 use_default_theme()
-insanity_main()
+modern_forced_induction_main()


### PR DESCRIPTION
## Summary
- add modular forced induction base nodes and modern production/track engine definitions (AMG M139, Volvo T6 twincharged, BMW B58, Porsche 911 GT2 RS, Nissan VR38DETT, Ford GT, Dodge Hellcat, Ferrari 488 GT3, Koenigsegg Jesko)
- provide performance and track vehicle/transmission setups plus main entry points for the new collection
- switch the default main script to load the modern forced induction collection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cb40b6f3388325b6153f4593e15f77